### PR TITLE
Extract MCP error code strings into AbpMcpErrorCodes constants

### DIFF
--- a/src/AbpMcp/Dispatch/AbpMcpDispatcher.cs
+++ b/src/AbpMcp/Dispatch/AbpMcpDispatcher.cs
@@ -52,7 +52,7 @@ internal sealed class AbpMcpDispatcher : IAbpMcpDispatcher
         // but a stale agent could still target one by name. Re-check at the dispatcher boundary.
         if (_options.CurrentValue.DisabledTools.Contains(descriptor.Name))
         {
-            throw new AbpMcpToolException("DISABLED", $"Tool '{descriptor.Name}' is administratively disabled.");
+            throw new AbpMcpToolException(AbpMcpErrorCodes.Disabled, $"Tool '{descriptor.Name}' is administratively disabled.");
         }
 
         await EnsureAuthorizedAsync(httpContext, descriptor).ConfigureAwait(false);
@@ -83,7 +83,7 @@ internal sealed class AbpMcpDispatcher : IAbpMcpDispatcher
             var result = await _authorization.AuthorizeAsync(context.User, permission).ConfigureAwait(false);
             if (!result.Succeeded)
             {
-                throw new AbpMcpToolException("FORBIDDEN", $"Missing permission: {permission}");
+                throw new AbpMcpToolException(AbpMcpErrorCodes.Forbidden, $"Missing permission: {permission}");
             }
         }
     }
@@ -120,7 +120,7 @@ internal sealed class AbpMcpDispatcher : IAbpMcpDispatcher
 
             // Required parameter missing: surface a clear validation error to the agent.
             throw new AbpMcpToolException(
-                "VALIDATION_ERROR",
+                AbpMcpErrorCodes.ValidationError,
                 $"Missing required parameter '{parameter.Name}'.");
         }
 
@@ -160,24 +160,24 @@ internal sealed class AbpMcpDispatcher : IAbpMcpDispatcher
         {
             case AbpValidationException ve:
                 _logger.LogInformation(ex, "Tool {Tool} rejected invalid input", descriptor.Name);
-                return new AbpMcpToolException("VALIDATION_ERROR", ve.Message, ve);
+                return new AbpMcpToolException(AbpMcpErrorCodes.ValidationError, ve.Message, ve);
 
             case AbpAuthorizationException ae:
                 _logger.LogWarning(ex, "Tool {Tool} refused unauthorized caller", descriptor.Name);
-                return new AbpMcpToolException("FORBIDDEN", ae.Message, ae);
+                return new AbpMcpToolException(AbpMcpErrorCodes.Forbidden, ae.Message, ae);
 
             case BusinessException be:
                 // UserFriendlyException inherits BusinessException in ABP, so this branch handles both.
                 _logger.LogInformation(ex, "Tool {Tool} raised business exception {Code}", descriptor.Name, be.Code);
-                return new AbpMcpToolException(be.Code ?? "BUSINESS_ERROR", be.Message ?? string.Empty, be);
+                return new AbpMcpToolException(be.Code ?? AbpMcpErrorCodes.BusinessError, be.Message ?? string.Empty, be);
 
             case OperationCanceledException oce:
                 _logger.LogDebug(ex, "Tool {Tool} cancelled", descriptor.Name);
-                return new AbpMcpToolException("CANCELLED", "Operation cancelled.", oce);
+                return new AbpMcpToolException(AbpMcpErrorCodes.Cancelled, "Operation cancelled.", oce);
 
             default:
                 _logger.LogError(ex, "Tool {Tool} threw unhandled exception", descriptor.Name);
-                return new AbpMcpToolException("INTERNAL", "An internal error occurred.", ex);
+                return new AbpMcpToolException(AbpMcpErrorCodes.Internal, "An internal error occurred.", ex);
         }
     }
 }

--- a/src/AbpMcp/Dispatch/AbpMcpErrorCodes.cs
+++ b/src/AbpMcp/Dispatch/AbpMcpErrorCodes.cs
@@ -1,0 +1,30 @@
+namespace AbpMcp.Dispatch;
+
+/// <summary>
+/// Stable error code constants emitted by the MCP dispatcher and handler wiring.
+/// Code values are part of the wire contract that MCP clients (agents) branch on,
+/// so they must stay byte-stable across releases.
+/// </summary>
+public static class AbpMcpErrorCodes
+{
+    /// <summary>Input failed validation (DTO required field missing, value out of range, etc.).</summary>
+    public const string ValidationError = "VALIDATION_ERROR";
+
+    /// <summary>Caller is authenticated but lacks the required ABP permission.</summary>
+    public const string Forbidden = "FORBIDDEN";
+
+    /// <summary>Tool name is not registered (or was removed).</summary>
+    public const string UnknownTool = "UNKNOWN_TOOL";
+
+    /// <summary>Tool is administratively disabled via AbpMcpOptions.DisabledTools.</summary>
+    public const string Disabled = "DISABLED";
+
+    /// <summary>The underlying ABP service raised a BusinessException; Code is the ABP code if present.</summary>
+    public const string BusinessError = "BUSINESS_ERROR";
+
+    /// <summary>Request was cancelled (client disconnected, timeout, etc.).</summary>
+    public const string Cancelled = "CANCELLED";
+
+    /// <summary>Unhandled exception. No stack trace is leaked to the agent.</summary>
+    public const string Internal = "INTERNAL";
+}

--- a/src/AbpMcp/Registration/AbpMcpHandlerWiring.cs
+++ b/src/AbpMcp/Registration/AbpMcpHandlerWiring.cs
@@ -86,12 +86,12 @@ internal sealed class AbpMcpHandlerWiring : IConfigureOptions<McpServerOptions>
 
         if (abpOptions.DisabledTools.Contains(toolName))
         {
-            return ErrorResult("DISABLED", $"Tool '{toolName}' is administratively disabled.");
+            return ErrorResult(AbpMcpErrorCodes.Disabled, $"Tool '{toolName}' is administratively disabled.");
         }
 
         if (!registry.TryGetByName(toolName, out var descriptor) || descriptor is null)
         {
-            return ErrorResult("UNKNOWN_TOOL", $"No tool named '{toolName}' is registered.");
+            return ErrorResult(AbpMcpErrorCodes.UnknownTool, $"No tool named '{toolName}' is registered.");
         }
 
         try


### PR DESCRIPTION
Resolves #16.

MCP error codes were scattered as string literals across the dispatcher and handler-wiring code (`AbpMcpDispatcher.MapException`, `AbpMcpDispatcher.MapArguments`, `AbpMcpHandlerWiring.HandleCallAsync`). A typo in any of these is a silent contract break — the agent sees a different error code than expected and can't branch correctly. With the values spread out, tests can't easily protect against typos.

## Change

- New file `src/AbpMcp/Dispatch/AbpMcpErrorCodes.cs` with `public const string` fields for every code, each carrying an XML `<summary>` so the project's `GenerateDocumentationFile` + `TreatWarningsAsErrors` stay clean.
- Replace every string literal in `AbpMcpDispatcher` (7 sites: `Disabled`, `Forbidden` x2, `ValidationError` x2, `BusinessError`, `Cancelled`, `Internal`) and `AbpMcpHandlerWiring` (2 sites: `Disabled`, `UnknownTool`) with the corresponding constant.
- The `BusinessException.Code ?? "BUSINESS_ERROR"` fallback in `MapException` now reads the constant too — same wire value, single source of truth.

## Acceptance criteria

- [x] `src/AbpMcp/Dispatch/AbpMcpErrorCodes.cs` exists with all codes as `public const string`, each XML-documented.
- [x] Every string literal in `AbpMcpDispatcher` and `AbpMcpHandlerWiring` replaced with the constant — verified with `grep -E '"VALIDATION_ERROR|"FORBIDDEN|"BUSINESS_ERROR|"CANCELLED|"INTERNAL|"DISABLED|"UNKNOWN_TOOL"'` returning no hits in those files.
- [x] Pure refactor — wire-format strings are unchanged, no behavior change.