### PR TITLE
refactor(dispatch): extract MCP error code constants

### DIFF
--- a/src/AbpMcp/Dispatch/AbpMcpDispatcher.cs
+++ b/src/AbpMcp/Dispatch/AbpMcpDispatcher.cs
@@ -52,7 +52,7 @@ internal sealed class AbpMcpDispatcher : IAbpMcpDispatcher
         // but a stale agent could still target one by name. Re-check at the dispatcher boundary.
         if (_options.CurrentValue.DisabledTools.Contains(descriptor.Name))
         {
-            throw new AbpMcpToolException("DISABLED", $"Tool '{descriptor.Name}' is administratively disabled.");
+            throw new AbpMcpToolException(AbpMcpErrorCodes.Disabled, $"Tool '{descriptor.Name}' is administratively disabled.");
         }
 
         await EnsureAuthorizedAsync(httpContext, descriptor).ConfigureAwait(false);
@@ -83,7 +83,7 @@ internal sealed class AbpMcpDispatcher : IAbpMcpDispatcher
             var result = await _authorization.AuthorizeAsync(context.User, permission).ConfigureAwait(false);
             if (!result.Succeeded)
             {
-                throw new AbpMcpToolException("FORBIDDEN", $"Missing permission: {permission}");
+                throw new AbpMcpToolException(AbpMcpErrorCodes.Forbidden, $"Missing permission: {permission}");
             }
         }
     }
@@ -120,7 +120,7 @@ internal sealed class AbpMcpDispatcher : IAbpMcpDispatcher
 
             // Required parameter missing: surface a clear validation error to the agent.
             throw new AbpMcpToolException(
-                "VALIDATION_ERROR",
+                AbpMcpErrorCodes.ValidationError,
                 $"Missing required parameter '{parameter.Name}'.");
         }
 
@@ -160,24 +160,24 @@ internal sealed class AbpMcpDispatcher : IAbpMcpDispatcher
         {
             case AbpValidationException ve:
                 _logger.LogInformation(ex, "Tool {Tool} rejected invalid input", descriptor.Name);
-                return new AbpMcpToolException("VALIDATION_ERROR", ve.Message, ve);
+                return new AbpMcpToolException(AbpMcpErrorCodes.ValidationError, ve.Message, ve);
 
             case AbpAuthorizationException ae:
                 _logger.LogWarning(ex, "Tool {Tool} refused unauthorized caller", descriptor.Name);
-                return new AbpMcpToolException("FORBIDDEN", ae.Message, ae);
+                return new AbpMcpToolException(AbpMcpErrorCodes.Forbidden, ae.Message, ae);
 
             case BusinessException be:
                 // UserFriendlyException inherits BusinessException in ABP, so this branch handles both.
                 _logger.LogInformation(ex, "Tool {Tool} raised business exception {Code}", descriptor.Name, be.Code);
-                return new AbpMcpToolException(be.Code ?? "BUSINESS_ERROR", be.Message ?? string.Empty, be);
+                return new AbpMcpToolException(be.Code ?? AbpMcpErrorCodes.BusinessError, be.Message ?? string.Empty, be);
 
             case OperationCanceledException oce:
                 _logger.LogDebug(ex, "Tool {Tool} cancelled", descriptor.Name);
-                return new AbpMcpToolException("CANCELLED", "Operation cancelled.", oce);
+                return new AbpMcpToolException(AbpMcpErrorCodes.Cancelled, "Operation cancelled.", oce);
 
             default:
                 _logger.LogError(ex, "Tool {Tool} threw unhandled exception", descriptor.Name);
-                return new AbpMcpToolException("INTERNAL", "An internal error occurred.", ex);
+                return new AbpMcpToolException(AbpMcpErrorCodes.Internal, "An internal error occurred.", ex);
         }
     }
 }

--- a/src/AbpMcp/Dispatch/AbpMcpErrorCodes.cs
+++ b/src/AbpMcp/Dispatch/AbpMcpErrorCodes.cs
@@ -1,0 +1,28 @@
+namespace AbpMcp.Dispatch;
+
+/// <summary>
+/// Stable MCP error codes returned to agents.
+/// </summary>
+public static class AbpMcpErrorCodes
+{
+    /// <summary>Input failed validation (DTO required field missing, value out of range, etc.).</summary>
+    public const string ValidationError = "VALIDATION_ERROR";
+
+    /// <summary>Caller is authenticated but lacks the required ABP permission.</summary>
+    public const string Forbidden = "FORBIDDEN";
+
+    /// <summary>Tool name is not registered (or was removed).</summary>
+    public const string UnknownTool = "UNKNOWN_TOOL";
+
+    /// <summary>Tool is administratively disabled via AbpMcpOptions.DisabledTools.</summary>
+    public const string Disabled = "DISABLED";
+
+    /// <summary>The underlying ABP service raised a BusinessException; Code is the ABP code if present.</summary>
+    public const string BusinessError = "BUSINESS_ERROR";
+
+    /// <summary>Request was cancelled (client disconnected, timeout, etc.).</summary>
+    public const string Cancelled = "CANCELLED";
+
+    /// <summary>Unhandled exception. No stack trace is leaked to the agent.</summary>
+    public const string Internal = "INTERNAL";
+}

--- a/src/AbpMcp/Dispatch/AbpMcpToolException.cs
+++ b/src/AbpMcp/Dispatch/AbpMcpToolException.cs
@@ -6,7 +6,7 @@ namespace AbpMcp.Dispatch;
 /// </summary>
 public sealed class AbpMcpToolException : Exception
 {
-    /// <summary>Stable error code (e.g. <c>FORBIDDEN</c>, <c>VALIDATION_ERROR</c>, <c>INTERNAL</c>).</summary>
+    /// <summary>Stable error code (see <see cref="AbpMcpErrorCodes"/>).</summary>
     public string Code { get; }
 
     /// <inheritdoc/>

--- a/src/AbpMcp/Registration/AbpMcpHandlerWiring.cs
+++ b/src/AbpMcp/Registration/AbpMcpHandlerWiring.cs
@@ -86,12 +86,12 @@ internal sealed class AbpMcpHandlerWiring : IConfigureOptions<McpServerOptions>
 
         if (abpOptions.DisabledTools.Contains(toolName))
         {
-            return ErrorResult("DISABLED", $"Tool '{toolName}' is administratively disabled.");
+            return ErrorResult(AbpMcpErrorCodes.Disabled, $"Tool '{toolName}' is administratively disabled.");
         }
 
         if (!registry.TryGetByName(toolName, out var descriptor) || descriptor is null)
         {
-            return ErrorResult("UNKNOWN_TOOL", $"No tool named '{toolName}' is registered.");
+            return ErrorResult(AbpMcpErrorCodes.UnknownTool, $"No tool named '{toolName}' is registered.");
         }
 
         try

--- a/test/AbpMcp.IntegrationTests/Tools/DispatcherInvocationTests.cs
+++ b/test/AbpMcp.IntegrationTests/Tools/DispatcherInvocationTests.cs
@@ -123,7 +123,7 @@ public sealed class DispatcherInvocationTests : AbpMcpIntegrationTestBase
                 var act = async () => await dispatcher.InvokeAsync(descriptor!, args.RootElement, CancellationToken.None);
 
                 var thrown = await act.Should().ThrowAsync<AbpMcpToolException>();
-                thrown.Which.Code.Should().Be("DISABLED");
+                thrown.Which.Code.Should().Be(AbpMcpErrorCodes.Disabled);
 
                 // The DB must remain pristine — kill switch fires before service invocation.
                 var db = services.GetRequiredService<BookDbContext>();


### PR DESCRIPTION
## Summary
- Add `AbpMcpErrorCodes` with `const string` fields for each MCP error code.
- Replace string literals in `AbpMcpDispatcher`, `AbpMcpHandlerWiring`, and integration tests.

## Related issue
Fixes #16